### PR TITLE
Upgrade JUnit to 4.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.13</version>
+            <version>4.13.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
JUnit 4.13.1 contains a security fix.

- `TemporaryFolder` rule now limits access to temporary folders on Java 1.7 or later

https://github.com/junit-team/junit4/blob/main/doc/ReleaseNotes4.13.1.md